### PR TITLE
update build arg to work around codebuild bug

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+Update docker build arg name to work in CI/CD environment

--- a/src/commands/up/index.ts
+++ b/src/commands/up/index.ts
@@ -75,7 +75,7 @@ function runBackend (dependencies: string, dir: string, file: string) {
   try {
     logger.info('Launching backend on localhost:8000');
     const commands = [
-      `docker build --pull --build-arg DEPENDENCIES=${dependencies} -f ${API_FILEPATH} -t ops-api . || exit 1`,
+      `docker build --pull --build-arg RUNTIME_DEPENDENCIES=${dependencies} -f ${API_FILEPATH} -t ops-api . || exit 1`,
       'docker container stop ops-api || true',
       'docker container rm ops-api || true',
       `docker run --name ops-api -v $HOME/.aws:/root/.aws -v ${dir}:/config --env CONFIG_PATH="../config/${file}" -i -p 8000:8000 --network=ops-console ops-api;`
@@ -97,7 +97,7 @@ function runFrontend (dependencies: string) {
   try {
     logger.info('Launching frontend on localhost:3000');
     const commands = [
-      `docker build --pull --build-arg DEPENDENCIES=${dependencies} -f ${UI_FILEPATH} -t ops-frontend . || exit 1`,
+      `docker build --pull --build-arg RUNTIME_DEPENDENCIES=${dependencies} -f ${UI_FILEPATH} -t ops-frontend . || exit 1`,
       'docker container stop ops-frontend || true',
       'docker container rm ops-frontend || true',
       'docker run --name ops-frontend --env AWS_REGION=us-west-2 --env API_ENDPOINT=http://ops-api:8000 -i -p 3000:3000 --network=ops-console ops-frontend;'


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [ ] Bug Fix
 - [x] Patch

## Summary of Patch
Update docker build-arg name from DEPENDENCIES to RUNTIME_DEPENDENCIES.
For whatever reason, the former build arg name wasn't being passed through by CodeBuild during the SaaS builds.  Simply changing the name resolves the issue.