### PR TITLE
Signup reroute

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+Fix signup url. Add providers to cli widgets in samples.

--- a/samples/ecs-dashboard-sample.yml
+++ b/samples/ecs-dashboard-sample.yml
@@ -273,6 +273,8 @@ Console:
     EcsProcesses:
       type: Cli
       displayName: List processes
+      providers:
+        - $ref: '#/Console/providers/AwsLocalProvider'
       environmentVariables:
         AWS_REGION:
           $ref: '#/Console/widgets/EcsInfo'
@@ -288,6 +290,8 @@ Console:
     EcsDiskUtil:
       type: Cli
       displayName: Show Disk Utils
+      providers:
+        - $ref: '#/Console/providers/AwsLocalProvider'
       environmentVariables:
         AWS_REGION:
           $ref: '#/Console/widgets/EcsInfo'
@@ -303,6 +307,8 @@ Console:
     EcsNetworkConnectivity:
       type: Cli
       displayName: Internet Connectivity
+      providers:
+        - $ref: '#/Console/providers/AwsLocalProvider'
       environmentVariables:
         AWS_REGION:
           $ref: '#/Console/widgets/EcsInfo'

--- a/src/commands/signup/index.ts
+++ b/src/commands/signup/index.ts
@@ -19,8 +19,8 @@ function signup (options: SignupOptions = {}) {
         openCommand = 'xdg-open';
         break;
     }
-    logger.info('Opening https://ops.tinystacks.com in your default browser...');
-    execSync(`${openCommand} https://ops.tinystacks.com`);
+    logger.info('Opening https://ops.tinystacks.com/sign-up in your default browser...');
+    execSync(`${openCommand} https://ops.tinystacks.com/sign-up`);
   } catch (e) {
     logger.error(`Error during signup: ${e}`);
   }

--- a/test/commands/signup.test.ts
+++ b/test/commands/signup.test.ts
@@ -27,10 +27,10 @@ describe('signup', () => {
     await signup({ os: 'darwin' });
 
     expect(mockExecSync).toBeCalled();
-    expect(mockExecSync).toBeCalledWith('open https://ops.tinystacks.com');
+    expect(mockExecSync).toBeCalledWith('open https://ops.tinystacks.com/sign-up');
 
     expect(mockLoggerInfo).toBeCalled();
-    expect(mockLoggerInfo).toBeCalledWith('Opening https://ops.tinystacks.com in your default browser...');
+    expect(mockLoggerInfo).toBeCalledWith('Opening https://ops.tinystacks.com/sign-up in your default browser...');
     
     expect(mockLoggerError).toBeCalled();
     expect(mockLoggerError).toBeCalledWith(`Error during signup: ${mockError}`);
@@ -39,18 +39,18 @@ describe('signup', () => {
     await signup({ os: 'win32' });
 
     expect(mockLoggerInfo).toBeCalled();
-    expect(mockLoggerInfo).toBeCalledWith('Opening https://ops.tinystacks.com in your default browser...');
+    expect(mockLoggerInfo).toBeCalledWith('Opening https://ops.tinystacks.com/sign-up in your default browser...');
 
     expect(mockExecSync).toBeCalled();
-    expect(mockExecSync).toBeCalledWith('start https://ops.tinystacks.com');
+    expect(mockExecSync).toBeCalledWith('start https://ops.tinystacks.com/sign-up');
   });
   it('opens url with xdg-open for linux', async () => {
     await signup({ os: 'linux' });
 
     expect(mockLoggerInfo).toBeCalled();
-    expect(mockLoggerInfo).toBeCalledWith('Opening https://ops.tinystacks.com in your default browser...');
+    expect(mockLoggerInfo).toBeCalledWith('Opening https://ops.tinystacks.com/sign-up in your default browser...');
 
     expect(mockExecSync).toBeCalled();
-    expect(mockExecSync).toBeCalledWith('xdg-open https://ops.tinystacks.com');
+    expect(mockExecSync).toBeCalledWith('xdg-open https://ops.tinystacks.com/sign-up');
   });
 });


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [x] Bug Fix

## Summary of Bug Fix(es)
### Previous Behaviour
1. signup cli command took us straight to the main site
2. ecs-dashboard-sample didn't include aws creds providers to CLI commands that needed them
### New Behaviour
1. redirect to /sign-up
2. add providers. those widgets now work
